### PR TITLE
feat: 리프레시 토큰을 사용한 액세스 토큰 자동 갱신 구현

### DIFF
--- a/timefit-front/src/app/api/auth/refresh/route.ts
+++ b/timefit-front/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getIronSession } from 'iron-session';
+import {
+  RefreshRequestBody,
+  RefreshApiResponse,
+  RefreshHandlerResponse,
+  RefreshHandlerSuccessResponse,
+  RefreshHandlerErrorResponse,
+} from '@/types/auth/refresh';
+import { sessionOptions, SessionData } from '@/lib/session/options';
+
+const BACKEND_API_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = (await request.json()) as RefreshRequestBody;
+
+    if (!body.refreshToken) {
+      const errorPayload: RefreshHandlerErrorResponse = {
+        success: false,
+        message: '리프레시 토큰이 필요합니다.',
+      };
+      return NextResponse.json<RefreshHandlerResponse>(errorPayload, {
+        status: 400,
+      });
+    }
+
+    const response = await fetch(`${BACKEND_API_URL}/api/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const responseData = (await response.json()) as RefreshApiResponse;
+
+    if (!response.ok) {
+      const errorPayload: RefreshHandlerErrorResponse = {
+        success: false,
+        message: responseData.message || '토큰 갱신에 실패했습니다.',
+      };
+
+      const responseJson = NextResponse.json<RefreshHandlerResponse>(
+        errorPayload,
+        { status: response.status }
+      );
+
+      // 리프레시 토큰도 만료된 경우 세션 파괴
+      if (response.status === 401) {
+        const session = await getIronSession<SessionData>(
+          request,
+          responseJson,
+          sessionOptions
+        );
+        session.destroy();
+      }
+
+      return responseJson;
+    }
+
+    const newAccessToken = responseData.data?.accessToken;
+    const newRefreshToken = responseData.data?.refreshToken;
+
+    if (!newAccessToken || !newRefreshToken) {
+      const errorPayload: RefreshHandlerErrorResponse = {
+        success: false,
+        message: '새로운 토큰이 응답에 포함되어 있지 않습니다.',
+      };
+      const responseJson = NextResponse.json<RefreshHandlerResponse>(
+        errorPayload,
+        { status: 500 }
+      );
+      const session = await getIronSession<SessionData>(
+        request,
+        responseJson,
+        sessionOptions
+      );
+      session.destroy();
+      return responseJson;
+    }
+
+    const successPayload: RefreshHandlerSuccessResponse = {
+      success: true,
+      message: '토큰이 갱신되었습니다.',
+      data: responseData.data!,
+    };
+
+    const responseJson =
+      NextResponse.json<RefreshHandlerResponse>(successPayload);
+
+    // 세션 업데이트
+    const session = await getIronSession<SessionData>(
+      request,
+      responseJson,
+      sessionOptions
+    );
+
+    if (session.user) {
+      session.user.accessToken = newAccessToken;
+      session.user.refreshToken = newRefreshToken;
+      await session.save();
+    }
+
+    return responseJson;
+  } catch (error) {
+    console.error('토큰 갱신 API 오류:', error);
+    const errorPayload: RefreshHandlerErrorResponse = {
+      success: false,
+      message: '서버 오류가 발생했습니다.',
+    };
+
+    const responseJson = NextResponse.json(errorPayload, { status: 500 });
+    const session = await getIronSession<SessionData>(
+      request,
+      responseJson,
+      sessionOptions
+    );
+    session.destroy();
+    return responseJson;
+  }
+}

--- a/timefit-front/src/app/api/auth/signout/route.ts
+++ b/timefit-front/src/app/api/auth/signout/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getIronSession } from 'iron-session';
+import { sessionOptions, SessionData } from '@/lib/session/options';
+
+export async function POST(request: NextRequest) {
+  try {
+    const responseJson = NextResponse.json({
+      success: true,
+      message: '로그아웃되었습니다.',
+    });
+
+    const session = await getIronSession<SessionData>(
+      request,
+      responseJson,
+      sessionOptions
+    );
+
+    session.destroy();
+
+    return responseJson;
+  } catch (error) {
+    console.error('로그아웃 API 오류:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        message: '로그아웃 처리 중 오류가 발생했습니다.',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/timefit-front/src/lib/auth/serverTokenManager.ts
+++ b/timefit-front/src/lib/auth/serverTokenManager.ts
@@ -1,0 +1,107 @@
+import type { SessionData } from '@/lib/session/options';
+import type { IronSession } from 'iron-session';
+
+const BACKEND_API_URL =
+  process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:8080';
+
+interface RefreshTokenResponse {
+  success: boolean;
+  message?: string;
+  data?: {
+    accessToken: string;
+    refreshToken: string;
+    tokenType: string;
+    expiresIn: number;
+  };
+}
+
+/**
+ * 서버 사이드에서 리프레시 토큰으로 액세스 토큰을 갱신합니다.
+ * @param session iron-session 객체
+ * @returns 갱신 성공 여부
+ */
+export async function refreshTokenOnServer(
+  session: IronSession<SessionData>
+): Promise<boolean> {
+  const refreshToken = session.user?.refreshToken;
+
+  if (!refreshToken) {
+    console.error('리프레시 토큰이 없습니다.');
+    session.destroy();
+    return false;
+  }
+
+  try {
+    const response = await fetch(`${BACKEND_API_URL}/api/auth/refresh`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ refreshToken }),
+    });
+
+    const data = (await response.json()) as RefreshTokenResponse;
+
+    if (!response.ok || !data.success) {
+      console.error('토큰 갱신 실패:', data.message);
+      session.destroy();
+      return false;
+    }
+
+    // 세션 업데이트
+    if (session.user && data.data) {
+      session.user.accessToken = data.data.accessToken;
+      session.user.refreshToken = data.data.refreshToken;
+      await session.save();
+      console.log('토큰 갱신 성공');
+      return true;
+    }
+
+    session.destroy();
+    return false;
+  } catch (error) {
+    console.error('토큰 갱신 중 오류:', error);
+    session.destroy();
+    return false;
+  }
+}
+
+/**
+ * API 요청을 실행하고, 401 에러 발생 시 토큰 갱신을 시도합니다.
+ * @param session iron-session 객체
+ * @param apiCall API 호출 함수 (accessToken을 인자로 받음)
+ * @returns API 응답 또는 null (토큰 갱신 실패 시)
+ */
+export async function executeWithTokenRefresh<T>(
+  session: IronSession<SessionData>,
+  apiCall: (accessToken: string) => Promise<Response>
+): Promise<Response | null> {
+  const accessToken = session.user?.accessToken;
+
+  if (!accessToken) {
+    return null;
+  }
+
+  // 첫 번째 시도
+  let response = await apiCall(accessToken);
+
+  // 401 에러 발생 시 토큰 갱신 시도
+  if (response.status === 401) {
+    console.log('401 에러 발생, 토큰 갱신 시도...');
+    const refreshed = await refreshTokenOnServer(session);
+
+    if (!refreshed) {
+      return null;
+    }
+
+    // 갱신된 토큰으로 재시도
+    const newAccessToken = session.user?.accessToken;
+    if (newAccessToken) {
+      response = await apiCall(newAccessToken);
+    } else {
+      return null;
+    }
+  }
+
+  return response;
+}

--- a/timefit-front/src/lib/auth/tokenManager.ts
+++ b/timefit-front/src/lib/auth/tokenManager.ts
@@ -1,0 +1,81 @@
+import type {
+  RefreshRequestBody,
+  RefreshHandlerResponse,
+} from '@/types/auth/refresh';
+
+/**
+ * 리프레시 토큰으로 액세스 토큰을 갱신합니다.
+ * @param refreshToken 리프레시 토큰
+ * @returns 갱신 결과
+ */
+export async function refreshAccessToken(
+  refreshToken: string
+): Promise<RefreshHandlerResponse> {
+  const requestBody: RefreshRequestBody = { refreshToken };
+
+  const response = await fetch('/api/auth/refresh', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+    body: JSON.stringify(requestBody),
+  });
+
+  const data = (await response.json()) as RefreshHandlerResponse;
+  return data;
+}
+
+/**
+ * 로그아웃을 수행합니다.
+ * @returns 로그아웃 결과
+ */
+export async function signOut(): Promise<{
+  success: boolean;
+  message: string;
+}> {
+  const response = await fetch('/api/auth/signout', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    credentials: 'include',
+  });
+
+  const data = await response.json();
+  return data;
+}
+
+/**
+ * 토큰 만료 여부를 확인합니다 (JWT 디코딩 없이 응답 상태로 확인).
+ * API 요청 실패 시 토큰 갱신을 시도하고, 갱신 실패 시 로그아웃합니다.
+ */
+export async function handleTokenRefresh(
+  refreshToken: string | undefined
+): Promise<boolean> {
+  if (!refreshToken) {
+    console.warn('리프레시 토큰이 없습니다. 로그아웃 처리합니다.');
+    await signOut();
+    window.location.href = '/signin';
+    return false;
+  }
+
+  try {
+    const result = await refreshAccessToken(refreshToken);
+
+    if (result.success) {
+      console.log('토큰이 갱신되었습니다.');
+      return true;
+    } else {
+      console.error('토큰 갱신 실패:', result.message);
+      await signOut();
+      window.location.href = '/signin';
+      return false;
+    }
+  } catch (error) {
+    console.error('토큰 갱신 중 오류 발생:', error);
+    await signOut();
+    window.location.href = '/signin';
+    return false;
+  }
+}

--- a/timefit-front/src/lib/cookie.ts
+++ b/timefit-front/src/lib/cookie.ts
@@ -3,6 +3,9 @@ import { cookies } from 'next/headers';
 export const ACCESS_TOKEN_COOKIE_NAME = 'accessToken';
 export const ACCESS_TOKEN_MAX_AGE = 60 * 15; // 15 minutes
 
+export const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken';
+export const REFRESH_TOKEN_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
 const isProduction = process.env.NODE_ENV === 'production';
 
 interface SetAccessTokenOptions {
@@ -46,4 +49,47 @@ export async function getAccessTokenFromCookie(): Promise<string | undefined> {
  */
 export async function hasAccessTokenCookie(): Promise<boolean> {
   return Boolean(await getAccessTokenFromCookie());
+}
+
+interface SetRefreshTokenOptions {
+  maxAge?: number;
+}
+
+/**
+ * 리프레시 토큰을 httpOnly 쿠키로 저장.
+ */
+export async function setRefreshTokenCookie(
+  token: string,
+  options: SetRefreshTokenOptions = {}
+) {
+  (await cookies()).set({
+    name: REFRESH_TOKEN_COOKIE_NAME,
+    value: token,
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: options.maxAge ?? REFRESH_TOKEN_MAX_AGE,
+  });
+}
+
+/**
+ * 저장된 리프레시 토큰 쿠키를 제거.
+ */
+export async function clearRefreshTokenCookie() {
+  (await cookies()).delete(REFRESH_TOKEN_COOKIE_NAME);
+}
+
+/**
+ * 쿠키에 저장된 리프레시 토큰을 반환.
+ */
+export async function getRefreshTokenFromCookie(): Promise<string | undefined> {
+  return (await cookies()).get(REFRESH_TOKEN_COOKIE_NAME)?.value;
+}
+
+/**
+ * 리프레시 토큰 쿠키 존재 여부를 확인.
+ */
+export async function hasRefreshTokenCookie(): Promise<boolean> {
+  return Boolean(await getRefreshTokenFromCookie());
 }

--- a/timefit-front/src/types/auth/refresh.ts
+++ b/timefit-front/src/types/auth/refresh.ts
@@ -1,0 +1,49 @@
+/**
+ * 백엔드 토큰 갱신 요청 본문.
+ */
+export interface RefreshRequestBody {
+  refreshToken: string;
+}
+
+/**
+ * 백엔드 토큰 갱신 응답 데이터.
+ */
+export interface RefreshTokenData {
+  accessToken: string;
+  refreshToken: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+/**
+ * 백엔드 토큰 갱신 응답 구조.
+ */
+export interface RefreshApiResponse {
+  success: boolean;
+  message?: string;
+  data?: RefreshTokenData;
+}
+
+/**
+ * Next.js 토큰 갱신 라우트 성공 응답.
+ */
+export interface RefreshHandlerSuccessResponse {
+  success: true;
+  message: string;
+  data: RefreshTokenData;
+}
+
+/**
+ * Next.js 토큰 갱신 라우트 실패 응답.
+ */
+export interface RefreshHandlerErrorResponse {
+  success: false;
+  message: string;
+}
+
+/**
+ * 토큰 갱신 라우트의 응답 타입.
+ */
+export type RefreshHandlerResponse =
+  | RefreshHandlerSuccessResponse
+  | RefreshHandlerErrorResponse;

--- a/timefit-front/src/types/auth/signup.ts
+++ b/timefit-front/src/types/auth/signup.ts
@@ -21,6 +21,7 @@ export interface SignupApiResponse {
  */
 export interface SignupSuccessPayload extends AuthUserProfile {
   accessToken?: string;
+  refreshToken?: string;
 }
 
 /**


### PR DESCRIPTION
- 리프레시 토큰 쿠키 관리 함수 추가 (cookie.ts)
- 세션 타입에 refreshToken 필드 추가
- 로그인/회원가입 시 refreshToken 저장 로직 구현
- 토큰 갱신 API 라우트 추가 (/api/auth/refresh)
- 로그아웃 API 라우트 추가 (/api/auth/signout)
- 서버/클라이언트 토큰 관리 유틸리티 함수 추가
- 비즈니스 API에 자동 토큰 갱신 로직 적용
- 리프레시 토큰 만료 시 자동 로그아웃 처리

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds refresh-token–driven access token renewal across server/client, updates session/cookie handling, and introduces refresh/signout API routes.
> 
> - **Auth APIs**
>   - **New**: `POST /api/auth/refresh` for token renewal; `POST /api/auth/signout` to destroy session.
>   - **Signin/Signup**: Require `refreshToken`, include it in success payloads, store `{ accessToken, refreshToken }` in session; stricter error handling.
> - **Business API**
>   - Uses `iron-session` and `executeWithTokenRefresh` to auto-refresh on 401 before retrying `POST /api/business`.
> - **Server-side Token Management**
>   - **New**: `lib/auth/serverTokenManager.ts` with `refreshTokenOnServer` and `executeWithTokenRefresh` to refresh and retry requests.
> - **Client-side Token Utilities**
>   - **New**: `lib/auth/tokenManager.ts` with `refreshAccessToken`, `signOut`, and `handleTokenRefresh` (auto-logout on failure).
> - **Cookies & Types**
>   - **Cookies**: Add `refreshToken` httpOnly helpers alongside access token in `lib/cookie.ts`.
>   - **Types**: Add `types/auth/refresh.ts`; extend `SignupSuccessPayload` with `refreshToken`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 90909cda562b1e6b12cfed6ea9f5ee836e5681e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->