### PR TITLE
사업자 페이지 클라이언트 컴포넌트 내 상태, 로직을 계층별로 분리

### DIFF
--- a/timefit-front/src/app/(business)/b/calendar/calendar-client.tsx
+++ b/timefit-front/src/app/(business)/b/calendar/calendar-client.tsx
@@ -1,22 +1,19 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import timeGridPlugin from '@fullcalendar/timegrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import koLocale from '@fullcalendar/core/locales/ko';
-import type { EventClickArg, DatesSetArg, EventInput } from '@fullcalendar/core';
-import dayjs from 'dayjs';
-import { toast } from 'sonner';
+import type { EventClickArg } from '@fullcalendar/core';
 
-import type { BusinessReservationItem, BusinessReservationDetail } from '@/types/business/reservation';
+import type { BusinessReservationItem } from '@/types/business/reservation';
 import type { ViewType } from '@/types/business/calendar';
-import { businessReservationService } from '@/services/reservation/reservation-business-service.client';
+import { useCalendar } from '@/hooks/business/calendar/use-calendar';
 import { ReservationDetailModal } from '@/components/business/reservations/reservation-detail-modal';
 import { CalendarMonthView } from '@/components/business/calendar/calendar-month-view';
 import { CalendarYearView } from '@/components/business/calendar/calendar-year-view';
 import { Button } from '@/components/ui/button';
-import { CALENDAR_MIN_HEIGHT, VIEW_LABELS } from '@/lib/constants/calendar';
+import { VIEW_LABELS } from '@/lib/constants/calendar';
 import { RESERVATION_STATUS_FILTERS } from '@/lib/constants/reservation-status';
 
 import '@/styles/fullcalendar-override.css';
@@ -27,189 +24,29 @@ interface CalendarClientProps {
 }
 
 export function CalendarClient({ initialReservations, businessId }: CalendarClientProps) {
-  const calendarRef = useRef<FullCalendar>(null);
-  const [currentView, setCurrentView] = useState<ViewType>('month');
-  const [currentDate, setCurrentDate] = useState(dayjs());
-  const [yearViewYear, setYearViewYear] = useState(dayjs().year());
-  const [allReservations, setAllReservations] = useState<BusinessReservationItem[]>(initialReservations);
-  const [activeStatuses, setActiveStatuses] = useState<Set<string>>(new Set(['CONFIRMED', 'COMPLETED']));
-  const [detailModal, setDetailModal] = useState<{ isOpen: boolean; detail: BusinessReservationDetail | null }>(
-    { isOpen: false, detail: null }
-  );
-
-  // 510px 이하에서 비율 축소
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [scale, setScale] = useState(1);
-  const SCALE_BREAKPOINT = 510;
-
-  useEffect(() => {
-    const handleResize = () => {
-      const width = window.innerWidth - 256; // 사이드바 너비 제외 (대략)
-      if (width < SCALE_BREAKPOINT) {
-        setScale(Math.max(0.6, width / SCALE_BREAKPOINT));
-      } else {
-        setScale(1);
-      }
-    };
-    handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, []);
-
-  const titleText = (() => {
-    if (currentView === 'year') return `${yearViewYear}년`;
-    if (currentView === 'month') return `${currentDate.year()}년 ${currentDate.month() + 1}월`;
-    if (currentView === 'timeGridDay') return `${currentDate.year()}년 ${currentDate.month() + 1}월 ${currentDate.date()}일`;
-    return calendarRef.current?.getApi().view.title ?? '';
-  })();
-
-  const toggleStatus = (status: string) => {
-    setActiveStatuses(prev => {
-      const next = new Set(prev);
-      if (next.has(status)) { if (next.size === 1) return prev; next.delete(status); }
-      else next.add(status);
-      return next;
-    });
-  };
-
-  const fetchReservations = useCallback(async (start: string, end: string) => {
-    try {
-      const params = new URLSearchParams();
-      params.append('startDate', start);
-      params.append('endDate', end);
-      params.append('size', '100');
-      const res = await fetch(`/api/business/${businessId}/reservations?${params.toString()}`);
-      const result = await res.json();
-      if (result.success && result.data) setAllReservations(result.data.reservations);
-    } catch { toast.error('예약 데이터를 불러오는 데 실패했습니다.'); }
-  }, [businessId]);
-
-  const handleDatesSet = useCallback((arg: DatesSetArg) => {
-    fetchReservations(
-      dayjs(arg.start).format('YYYY-MM-DD'),
-      dayjs(arg.end).subtract(1, 'day').format('YYYY-MM-DD')
-    );
-  }, [fetchReservations]);
-
-  const handleNavigate = (dir: number) => {
-    if (currentView === 'year') { setYearViewYear(y => y + dir); return; }
-    if (currentView === 'month') {
-      const next = currentDate.add(dir, 'month');
-      setCurrentDate(next);
-      fetchReservations(next.startOf('month').format('YYYY-MM-DD'), next.endOf('month').format('YYYY-MM-DD'));
-      return;
-    }
-    if (currentView === 'timeGridDay') {
-      const next = currentDate.add(dir, 'day');
-      setCurrentDate(next);
-      calendarRef.current?.getApi().gotoDate(next.toDate());
-      return;
-    }
-    if (dir === 1) calendarRef.current?.getApi().next();
-    else calendarRef.current?.getApi().prev();
-  };
-
-  const handleToday = () => {
-    const today = dayjs();
-    if (currentView === 'year') { setYearViewYear(today.year()); return; }
-    if (currentView === 'month') {
-      setCurrentDate(today);
-      fetchReservations(today.startOf('month').format('YYYY-MM-DD'), today.endOf('month').format('YYYY-MM-DD'));
-      return;
-    }
-    setCurrentDate(today);
-    calendarRef.current?.getApi().today();
-  };
-
-  const handleViewChange = (view: ViewType) => {
-    setCurrentView(view);
-    if (view === 'year' || view === 'month') return;
-    calendarRef.current?.getApi().changeView(view);
-  };
-
-  const handleMonthClick = (year: number, month: number) => {
-    const date = dayjs(new Date(year, month, 1));
-    setCurrentDate(date);
-    setCurrentView('month');
-    fetchReservations(date.startOf('month').format('YYYY-MM-DD'), date.endOf('month').format('YYYY-MM-DD'));
-  };
-
-  // 연 뷰 날짜 클릭 → 해당 날짜 기준 주 뷰로 이동
-  const handleDayClick = (year: number, month: number, day: number) => {
-    const date = dayjs(new Date(year, month, day));
-    setCurrentDate(date);
-    setCurrentView('timeGridWeek');
-    calendarRef.current?.getApi().changeView('timeGridWeek');
-    calendarRef.current?.getApi().gotoDate(date.toDate());
-  };
-
-  const handleMoreClick = (dateStr: string) => {
-    const date = dayjs(dateStr);
-    setCurrentDate(date);
-    setCurrentView('timeGridDay');
-    calendarRef.current?.getApi().changeView('timeGridDay');
-    calendarRef.current?.getApi().gotoDate(date.toDate());
-  };
-
-  const handleEventClick = async (reservationId: string) => {
-    const result = await businessReservationService.getReservationDetail(businessId, reservationId);
-    if (!result.success || !result.data) { toast.error('상세 정보를 불러오는 데 실패했습니다.'); return; }
-    setDetailModal({ isOpen: true, detail: result.data });
-  };
-
-  const fcEvents: EventInput[] = allReservations
-    .filter(r => activeStatuses.has(r.status))
-    .map(r => {
-      const filter = RESERVATION_STATUS_FILTERS.find(f => f.value === r.status);
-      return {
-        id: r.reservationId,
-        title: `${r.customerName} · ${r.reservationDuration}분`,
-        start: `${r.reservationDate}T${r.reservationTime}`,
-        end: dayjs(`${r.reservationDate}T${r.reservationTime}`).add(r.reservationDuration, 'minute').format('YYYY-MM-DDTHH:mm:ss'),
-        backgroundColor: filter?.eventColor ?? '#e5e7eb',
-        borderColor: filter?.eventColor ?? '#e5e7eb',
-        textColor: filter?.eventTextColor ?? '#374151',
-      };
-    });
+  const { view, scale, filter, modal, data, fcEvents } = useCalendar({ initialReservations, businessId });
 
   return (
-    // -m-4: 레이아웃 padding 상쇄
-    // min-height: 작은 화면에서도 그리드 최소 크기 보장 → 이하는 스크롤
-    <div
-      ref={containerRef}
-      className="-m-4 flex flex-col"
-      style={{
-        height: 'calc(100vh - 64px)',
-        minHeight: CALENDAR_MIN_HEIGHT,
-        // 월/연 뷰에서만 scale 축소 적용 (FullCalendar는 transform 호환 안됨)
-        transformOrigin: 'top left',
-        transform: scale < 1 && (currentView === 'month' || currentView === 'year')
-          ? `scale(${scale})` : undefined,
-        width: scale < 1 && (currentView === 'month' || currentView === 'year')
-          ? `${100 / scale}%` : undefined,
-        minWidth: currentView === 'timeGridWeek' || currentView === 'timeGridDay'
-          ? 506 : undefined,
-      }}
-    >
+    <div ref={scale.containerRef} className="-m-4 flex flex-col" style={scale.containerStyle}>
       {/* 툴바 + 필터 */}
       <div className="px-4 pt-4 pb-2 shrink-0 space-y-2">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <span className="text-lg font-medium min-w-[180px]">{titleText}</span>
+            <span className="text-lg font-medium min-w-[180px]">{view.titleText}</span>
             <div className="flex border border-border rounded-md overflow-hidden">
-              <Button variant="ghost" size="sm" className="rounded-none border-r border-border" onClick={() => handleNavigate(-1)}>‹</Button>
-              <Button variant="ghost" size="sm" className="rounded-none" onClick={() => handleNavigate(1)}>›</Button>
+              <Button variant="ghost" size="sm" className="rounded-none border-r border-border" onClick={() => view.handleNavigate(-1)}>‹</Button>
+              <Button variant="ghost" size="sm" className="rounded-none" onClick={() => view.handleNavigate(1)}>›</Button>
             </div>
-            <Button variant="outline" size="sm" onClick={handleToday}>오늘</Button>
+            <Button variant="outline" size="sm" onClick={view.handleToday}>오늘</Button>
           </div>
           <div className="flex border border-border rounded-md overflow-hidden">
             {(Object.keys(VIEW_LABELS) as ViewType[]).map(v => (
               <Button
                 key={v}
-                variant={currentView === v ? 'default' : 'ghost'}
+                variant={view.currentView === v ? 'default' : 'ghost'}
                 size="sm"
                 className="rounded-none border-r last:border-r-0 border-border"
-                onClick={() => handleViewChange(v)}
+                onClick={() => view.handleViewChange(v)}
               >
                 {VIEW_LABELS[v]}
               </Button>
@@ -224,53 +61,53 @@ export function CalendarClient({ initialReservations, businessId }: CalendarClie
               variant="outline"
               size="sm"
               className={`rounded-full text-xs transition-colors
-                ${activeStatuses.has(f.value) ? f.activeClass : 'bg-background text-muted-foreground border-border'}`}
-              onClick={() => toggleStatus(f.value)}
+                ${filter.activeStatuses.has(f.value) ? f.activeClass : 'bg-background text-muted-foreground border-border'}`}
+              onClick={() => filter.toggleStatus(f.value)}
             >
-              {activeStatuses.has(f.value) ? '● ' : '○ '}{f.label}
+              {filter.activeStatuses.has(f.value) ? '● ' : '○ '}{f.label}
             </Button>
           ))}
         </div>
       </div>
 
       {/* 월 뷰 */}
-      {currentView === 'month' && (
+      {view.currentView === 'month' && (
         <div className="flex-1 min-h-0 flex flex-col px-4 pb-4">
           <CalendarMonthView
-            year={currentDate.year()}
-            month={currentDate.month()}
-            reservations={allReservations}
-            activeStatuses={activeStatuses}
-            onEventClick={handleEventClick}
-            onMoreClick={handleMoreClick}
+            year={view.currentDate.year()}
+            month={view.currentDate.month()}
+            reservations={data.allReservations}
+            activeStatuses={filter.activeStatuses}
+            onEventClick={modal.handleEventClick}
+            onMoreClick={view.handleMoreClick}
           />
         </div>
       )}
 
       {/* 연 뷰 */}
-      {currentView === 'year' && (
+      {view.currentView === 'year' && (
         <div className="flex-1 overflow-y-auto px-4 pb-4">
           <CalendarYearView
-            year={yearViewYear}
-            onMonthClick={handleMonthClick}
-            onDayClick={handleDayClick}
+            year={view.yearViewYear}
+            onMonthClick={view.handleMonthClick}
+            onDayClick={view.handleDayClick}
           />
         </div>
       )}
 
       {/* 주/일 뷰 */}
       <div className={`flex-1 min-h-0 px-4 pb-4
-        ${currentView === 'timeGridWeek' || currentView === 'timeGridDay' ? '' : 'hidden'}`}>
+        ${view.currentView === 'timeGridWeek' || view.currentView === 'timeGridDay' ? '' : 'hidden'}`}>
         <FullCalendar
-          ref={calendarRef}
+          ref={view.calendarRef}
           plugins={[timeGridPlugin, interactionPlugin]}
           initialView="timeGridWeek"
           locale={koLocale}
           height="100%"
           headerToolbar={false}
           events={fcEvents}
-          eventClick={(arg: EventClickArg) => handleEventClick(arg.event.id)}
-          datesSet={handleDatesSet}
+          eventClick={(arg: EventClickArg) => modal.handleEventClick(arg.event.id)}
+          datesSet={view.handleDatesSet}
           allDaySlot={false}
           nowIndicator
           stickyHeaderDates={false}
@@ -278,9 +115,9 @@ export function CalendarClient({ initialReservations, businessId }: CalendarClie
       </div>
 
       <ReservationDetailModal
-        detail={detailModal.detail}
-        isOpen={detailModal.isOpen}
-        onClose={() => setDetailModal({ isOpen: false, detail: null })}
+        detail={modal.detailModal.detail}
+        isOpen={modal.detailModal.isOpen}
+        onClose={modal.closeDetailModal}
       />
     </div>
   );

--- a/timefit-front/src/app/(business)/b/customers/customers-client.tsx
+++ b/timefit-front/src/app/(business)/b/customers/customers-client.tsx
@@ -1,16 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { toast } from 'sonner';
-
 import type {
-  BusinessCustomerDetail,
   BusinessCustomerItem,
-  CustomerSortType,
 } from '@/types/business/customer-business';
 import type { PaginationInfo } from '@/types/business/reservation';
-
-import { businessCustomerService } from '@/services/business/customer-business-service.client';
+import { useCustomers } from '@/hooks/business/use-customers';
 import { CustomerCountDisplay } from '@/components/business/customers/customer-count-display';
 import { CustomerDetailModal } from '@/components/business/customers/customer-detail-modal';
 import { CustomerFilterToolbar } from '@/components/business/customers/customer-filter-toolbar';
@@ -19,8 +13,8 @@ import { CustomerTableEmpty } from '@/components/business/customers/customer-tab
 import { CustomerTableHeader } from '@/components/business/customers/customer-table-header';
 import { CustomerTableRow } from '@/components/business/customers/customer-table-row';
 import { CustomerPagination } from '@/components/business/customers/customer-pagination';
-import { Table, TableBody } from '@/components/ui/table';
 import { Card, CardContent } from '@/components/ui/card';
+import { Table, TableBody } from '@/components/ui/table';
 
 interface CustomersClientProps {
   initialCustomers: BusinessCustomerItem[];
@@ -33,108 +27,20 @@ export function CustomersClient({
                                   initialPagination,
                                   businessId,
                                 }: CustomersClientProps) {
-  const [customers, setCustomers] = useState<BusinessCustomerItem[]>(initialCustomers);
-  const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
-  const [isLoading, setIsLoading] = useState(false);
-  const [currentKeyword, setCurrentKeyword] = useState('');
-  const [currentSortBy, setCurrentSortBy] = useState<CustomerSortType>('LAST_VISIT');
-
-  // 상세 모달
-  const [detailModal, setDetailModal] = useState<{
-    isOpen: boolean;
-    detail: BusinessCustomerDetail | null;
-  }>({ isOpen: false, detail: null });
-
-  // 메모 다이얼로그
-  const [memoDialog, setMemoDialog] = useState<{
-    isOpen: boolean;
-    customerId: string;
-    currentMemo: string | null;
-  }>({ isOpen: false, customerId: '', currentMemo: null });
-
-  // 고객 목록 fetch
-  const fetchCustomers = async (
-    keyword: string,
-    sortBy: CustomerSortType,
-    page: number
-  ) => {
-    const params = new URLSearchParams();
-    if (keyword) params.append('keyword', keyword);
-    params.append('sortBy', sortBy);
-    params.append('page', page.toString());
-    params.append('size', '20');
-
-    const response = await fetch(
-      `/api/business/${businessId}/customers?${params.toString()}`
-    );
-    return response.json();
-  };
-
-  // 검색/정렬 변경
-  const handleSearch = async (keyword: string, sortBy: CustomerSortType) => {
-    try {
-      setIsLoading(true);
-      const result = await fetchCustomers(keyword, sortBy, 0);
-      if (!result.success) { toast.error('조회에 실패했습니다.'); return; }
-      setCurrentKeyword(keyword);
-      setCurrentSortBy(sortBy);
-      setCustomers(result.data.customers);
-      setPagination(result.data.pagination);
-    } catch {
-      toast.error('조회 중 오류가 발생했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 페이지 이동
-  const handlePageChange = async (page: number) => {
-    try {
-      setIsLoading(true);
-      const result = await fetchCustomers(currentKeyword, currentSortBy, page);
-      if (!result.success) { toast.error('페이지 로드에 실패했습니다.'); return; }
-      setCustomers(result.data.customers);
-      setPagination(result.data.pagination);
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    } catch {
-      toast.error('페이지 로드 중 오류가 발생했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 고객 상세
-  const handleDetail = async (customerId: string) => {
-    const result = await businessCustomerService.getCustomerDetail(businessId, customerId);
-    if (!result.success || !result.data) {
-      toast.error(result.message || '상세 정보를 불러오는 데 실패했습니다.');
-      return;
-    }
-    setDetailModal({ isOpen: true, detail: result.data });
-  };
-
-  // 메모 편집 열기
-  const handleMemo = (customerId: string, currentMemo: string | null) => {
-    setMemoDialog({ isOpen: true, customerId, currentMemo });
-  };
-
-  // 메모 저장
-  const handleMemoSave = async (memo: string | null) => {
-    const result = await businessCustomerService.upsertCustomerMemo(
-      businessId,
-      memoDialog.customerId,
-      memo
-    );
-    if (!result.success) {
-      toast.error(result.message || '메모 저장에 실패했습니다.');
-      return;
-    }
-    setCustomers(prev => prev.map(c =>
-      c.customerId === memoDialog.customerId ? { ...c, memo } : c
-    ));
-    toast.success('메모가 저장되었습니다.');
-    setMemoDialog({ isOpen: false, customerId: '', currentMemo: null });
-  };
+  const {
+    customers,
+    pagination,
+    isLoading,
+    detailModal,
+    memoDialog,
+    handleSearch,
+    handlePageChange,
+    handleDetail,
+    closeDetailModal,
+    handleMemo,
+    closeMemoDialog,
+    handleMemoSave,
+  } = useCustomers({ initialCustomers, initialPagination, businessId });
 
   return (
     <div className="space-y-6">
@@ -177,14 +83,14 @@ export function CustomersClient({
       <CustomerDetailModal
         detail={detailModal.detail}
         isOpen={detailModal.isOpen}
-        onClose={() => setDetailModal({ isOpen: false, detail: null })}
+        onClose={closeDetailModal}
         onMemo={handleMemo}
       />
 
       <CustomerMemoDialog
         isOpen={memoDialog.isOpen}
         currentMemo={memoDialog.currentMemo}
-        onClose={() => setMemoDialog({ isOpen: false, customerId: '', currentMemo: null })}
+        onClose={closeMemoDialog}
         onSave={handleMemoSave}
       />
     </div>

--- a/timefit-front/src/app/(business)/b/customers/customers-client.tsx
+++ b/timefit-front/src/app/(business)/b/customers/customers-client.tsx
@@ -8,6 +8,8 @@ import type {
   BusinessCustomerItem,
   CustomerSortType,
 } from '@/types/business/customer-business';
+import type { PaginationInfo } from '@/types/business/reservation';
+
 import { businessCustomerService } from '@/services/business/customer-business-service.client';
 import { CustomerCountDisplay } from '@/components/business/customers/customer-count-display';
 import { CustomerDetailModal } from '@/components/business/customers/customer-detail-modal';
@@ -19,15 +21,6 @@ import { CustomerTableRow } from '@/components/business/customers/customer-table
 import { CustomerPagination } from '@/components/business/customers/customer-pagination';
 import { Table, TableBody } from '@/components/ui/table';
 import { Card, CardContent } from '@/components/ui/card';
-
-interface PaginationInfo {
-  currentPage: number;
-  totalPages: number;
-  totalElements: number;
-  size: number;
-  hasNext: boolean;
-  hasPrevious: boolean;
-}
 
 interface CustomersClientProps {
   initialCustomers: BusinessCustomerItem[];

--- a/timefit-front/src/app/(business)/b/reservations/reservations-client.tsx
+++ b/timefit-front/src/app/(business)/b/reservations/reservations-client.tsx
@@ -54,38 +54,6 @@ export function ReservationsClient({
     endDate: today.add(15, 'day').format('YYYY-MM-DD'),
   });
 
-  // 예약 목록 fetch
-  const fetchReservations = async (filters: FilterValues, page: number) => {
-    const params = new URLSearchParams();
-    if (filters.status) params.append('status', filters.status);
-    if (filters.startDate) params.append('startDate', filters.startDate);
-    if (filters.endDate) params.append('endDate', filters.endDate);
-    if (filters.customerName) params.append('customerName', filters.customerName);
-    params.append('page', page.toString());
-    params.append('size', '20');
-
-    const response = await fetch(
-      `/api/business/${businessId}/reservations?${params.toString()}`
-    );
-    return response.json();
-  };
-
-  // 통계 fetch — 필터 조건 전체 동기화 (status, customerName 포함)
-  const fetchStats = async (filters: FilterValues) => {
-    const params = new URLSearchParams();
-    if (filters.status) params.append('status', filters.status);
-    if (filters.customerName) params.append('customerName', filters.customerName);
-    if (filters.startDate) params.append('startDate', filters.startDate);
-    if (filters.endDate) params.append('endDate', filters.endDate);
-
-    const queryString = params.toString();
-    const response = await fetch(
-      `/api/business/${businessId}/reservations/stats${queryString ? `?${queryString}` : ''}`
-    );
-    const result = await response.json();
-    if (result.success && result.data) setStats(result.data);
-  };
-
   // 상세 보기
   const handleDetail = async (reservationId: string) => {
     const result = await businessReservationService.getReservationDetail(businessId, reservationId);
@@ -96,18 +64,19 @@ export function ReservationsClient({
     setDetailModal({ isOpen: true, detail: result.data });
   };
 
-  // 필터 검색 — 목록 + 통계 동시 갱신 (전체 필터 동기화)
+  // 필터 검색 — 목록 + 통계 동시 갱신
   const handleSearch = async (filters: FilterValues) => {
     try {
       setIsLoading(true);
-      const [result] = await Promise.all([
-        fetchReservations(filters, 0),
-        fetchStats(filters),
+      const [listResult, statsResult] = await Promise.all([
+        businessReservationService.getReservations(businessId, { ...filters, page: 0, size: 20 }),
+        businessReservationService.getReservationStats(businessId, filters),
       ]);
-      if (!result.success) { toast.error('조회에 실패했습니다.'); return; }
+      if (!listResult.success) { toast.error('조회에 실패했습니다.'); return; }
       setCurrentFilters(filters);
-      setReservations(result.data.reservations);
-      setPagination(result.data.pagination);
+      setReservations(listResult.data!.reservations);
+      setPagination(listResult.data!.pagination);
+      if (statsResult.success && statsResult.data) setStats(statsResult.data);
     } catch {
       toast.error('조회 중 오류가 발생했습니다.');
     } finally {
@@ -115,14 +84,16 @@ export function ReservationsClient({
     }
   };
 
-  // 페이지 이동 (통계 재조회 불필요)
+  // 페이지 이동
   const handlePageChange = async (page: number) => {
     try {
       setIsLoading(true);
-      const result = await fetchReservations(currentFilters, page);
+      const result = await businessReservationService.getReservations(
+        businessId, { ...currentFilters, page, size: 20 }
+      );
       if (!result.success) { toast.error('페이지 로드에 실패했습니다.'); return; }
-      setReservations(result.data.reservations);
-      setPagination(result.data.pagination);
+      setReservations(result.data!.reservations);
+      setPagination(result.data!.pagination);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     } catch {
       toast.error('페이지 로드 중 오류가 발생했습니다.');
@@ -131,7 +102,13 @@ export function ReservationsClient({
     }
   };
 
-  // 액션 핸들러 — 현재 필터 기준으로 통계 재조회
+  // 통계 갱신
+  const refreshStats = async () => {
+    const result = await businessReservationService.getReservationStats(businessId, currentFilters);
+    if (result.success && result.data) setStats(result.data);
+  };
+
+  // 액션 핸들러
   const handleApprove = async (reservationId: string) => {
     const result = await businessReservationService.approveReservation(businessId, reservationId);
     if (!result.success) { toast.error(result.message || '승인에 실패했습니다.'); return; }
@@ -139,7 +116,7 @@ export function ReservationsClient({
       r.reservationId === reservationId ? { ...r, status: 'CONFIRMED' as const, requiresAction: false } : r
     ));
     toast.success('예약을 승인했습니다.');
-    await fetchStats(currentFilters);
+    await refreshStats();
   };
 
   const handleReject = async (reservationId: string) => {
@@ -149,7 +126,7 @@ export function ReservationsClient({
       r.reservationId === reservationId ? { ...r, status: 'REJECTED' as const, requiresAction: false } : r
     ));
     toast.success('예약을 거절했습니다.');
-    await fetchStats(currentFilters);
+    await refreshStats();
   };
 
   const handleComplete = async (reservationId: string) => {
@@ -159,7 +136,7 @@ export function ReservationsClient({
       r.reservationId === reservationId ? { ...r, status: 'COMPLETED' as const, requiresAction: false } : r
     ));
     toast.success('예약을 완료 처리했습니다.');
-    await fetchStats(currentFilters);
+    await refreshStats();
   };
 
   const handleNoShow = async (reservationId: string) => {
@@ -169,7 +146,7 @@ export function ReservationsClient({
       r.reservationId === reservationId ? { ...r, status: 'NO_SHOW' as const, requiresAction: false } : r
     ));
     toast.success('노쇼 처리했습니다.');
-    await fetchStats(currentFilters);
+    await refreshStats();
   };
 
   return (

--- a/timefit-front/src/app/(business)/b/reservations/reservations-client.tsx
+++ b/timefit-front/src/app/(business)/b/reservations/reservations-client.tsx
@@ -1,19 +1,13 @@
 'use client';
 
-import { useState } from 'react';
-import { toast } from 'sonner';
-import dayjs from 'dayjs';
-
 import type {
-  BusinessReservationDetail,
   BusinessReservationItem,
   PaginationInfo,
   ReservationStats,
 } from '@/types/business/reservation';
-import { businessReservationService } from '@/services/reservation/reservation-business-service.client';
+import { useReservations } from '@/hooks/business/use-reservations';
 import {
   ReservationFilterToolbar,
-  type FilterValues,
 } from '@/components/business/reservations/reservation-filter-toolbar';
 import { ReservationDetailModal } from '@/components/business/reservations/reservation-detail-modal';
 import { ReservationPagination } from '@/components/business/reservations/reservation-pagination';
@@ -36,118 +30,21 @@ export function ReservationsClient({
                                      initialStats,
                                      businessId,
                                    }: ReservationsClientProps) {
-  const [reservations, setReservations] = useState<BusinessReservationItem[]>(initialReservations);
-  const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
-  const [stats, setStats] = useState<ReservationStats>(initialStats);
-  const [isLoading, setIsLoading] = useState(false);
-
-  // 상세 모달
-  const [detailModal, setDetailModal] = useState<{
-    isOpen: boolean;
-    detail: BusinessReservationDetail | null;
-  }>({ isOpen: false, detail: null });
-
-  // page.tsx SSR과 동일한 기본값 ±15일
-  const today = dayjs();
-  const [currentFilters, setCurrentFilters] = useState<FilterValues>({
-    startDate: today.subtract(15, 'day').format('YYYY-MM-DD'),
-    endDate: today.add(15, 'day').format('YYYY-MM-DD'),
-  });
-
-  // 상세 보기
-  const handleDetail = async (reservationId: string) => {
-    const result = await businessReservationService.getReservationDetail(businessId, reservationId);
-    if (!result.success || !result.data) {
-      toast.error(result.message || '상세 정보를 불러오는 데 실패했습니다.');
-      return;
-    }
-    setDetailModal({ isOpen: true, detail: result.data });
-  };
-
-  // 필터 검색 — 목록 + 통계 동시 갱신
-  const handleSearch = async (filters: FilterValues) => {
-    try {
-      setIsLoading(true);
-      const [listResult, statsResult] = await Promise.all([
-        businessReservationService.getReservations(businessId, { ...filters, page: 0, size: 20 }),
-        businessReservationService.getReservationStats(businessId, filters),
-      ]);
-      if (!listResult.success) { toast.error('조회에 실패했습니다.'); return; }
-      setCurrentFilters(filters);
-      setReservations(listResult.data!.reservations);
-      setPagination(listResult.data!.pagination);
-      if (statsResult.success && statsResult.data) setStats(statsResult.data);
-    } catch {
-      toast.error('조회 중 오류가 발생했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 페이지 이동
-  const handlePageChange = async (page: number) => {
-    try {
-      setIsLoading(true);
-      const result = await businessReservationService.getReservations(
-        businessId, { ...currentFilters, page, size: 20 }
-      );
-      if (!result.success) { toast.error('페이지 로드에 실패했습니다.'); return; }
-      setReservations(result.data!.reservations);
-      setPagination(result.data!.pagination);
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-    } catch {
-      toast.error('페이지 로드 중 오류가 발생했습니다.');
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // 통계 갱신
-  const refreshStats = async () => {
-    const result = await businessReservationService.getReservationStats(businessId, currentFilters);
-    if (result.success && result.data) setStats(result.data);
-  };
-
-  // 액션 핸들러
-  const handleApprove = async (reservationId: string) => {
-    const result = await businessReservationService.approveReservation(businessId, reservationId);
-    if (!result.success) { toast.error(result.message || '승인에 실패했습니다.'); return; }
-    setReservations(prev => prev.map(r =>
-      r.reservationId === reservationId ? { ...r, status: 'CONFIRMED' as const, requiresAction: false } : r
-    ));
-    toast.success('예약을 승인했습니다.');
-    await refreshStats();
-  };
-
-  const handleReject = async (reservationId: string) => {
-    const result = await businessReservationService.rejectReservation(businessId, reservationId);
-    if (!result.success) { toast.error(result.message || '거절에 실패했습니다.'); return; }
-    setReservations(prev => prev.map(r =>
-      r.reservationId === reservationId ? { ...r, status: 'REJECTED' as const, requiresAction: false } : r
-    ));
-    toast.success('예약을 거절했습니다.');
-    await refreshStats();
-  };
-
-  const handleComplete = async (reservationId: string) => {
-    const result = await businessReservationService.completeReservation(businessId, reservationId);
-    if (!result.success) { toast.error(result.message || '완료 처리에 실패했습니다.'); return; }
-    setReservations(prev => prev.map(r =>
-      r.reservationId === reservationId ? { ...r, status: 'COMPLETED' as const, requiresAction: false } : r
-    ));
-    toast.success('예약을 완료 처리했습니다.');
-    await refreshStats();
-  };
-
-  const handleNoShow = async (reservationId: string) => {
-    const result = await businessReservationService.noShowReservation(businessId, reservationId);
-    if (!result.success) { toast.error(result.message || '노쇼 처리에 실패했습니다.'); return; }
-    setReservations(prev => prev.map(r =>
-      r.reservationId === reservationId ? { ...r, status: 'NO_SHOW' as const, requiresAction: false } : r
-    ));
-    toast.success('노쇼 처리했습니다.');
-    await refreshStats();
-  };
+  const {
+    reservations,
+    pagination,
+    stats,
+    isLoading,
+    detailModal,
+    handleDetail,
+    closeDetailModal,
+    handleSearch,
+    handlePageChange,
+    handleApprove,
+    handleReject,
+    handleComplete,
+    handleNoShow,
+  } = useReservations({ initialReservations, initialPagination, initialStats, businessId });
 
   return (
     <div className="space-y-6">
@@ -181,7 +78,7 @@ export function ReservationsClient({
       <ReservationDetailModal
         detail={detailModal.detail}
         isOpen={detailModal.isOpen}
-        onClose={() => setDetailModal({ isOpen: false, detail: null })}
+        onClose={closeDetailModal}
       />
     </div>
   );

--- a/timefit-front/src/app/(business)/b/settings/settings-client.tsx
+++ b/timefit-front/src/app/(business)/b/settings/settings-client.tsx
@@ -10,7 +10,7 @@ import type {
 } from '@/types/business/business-detail';
 import { useUpdateBusiness } from '@/hooks/business/mutations/use-update-business';
 import { validateBusinessContactPhone } from '@/lib/validators/business-validators';
-import { hasScriptInjection } from '@/lib/validators/input-validators';
+import { validateScriptInjection } from '@/lib/validators/input-validators';
 import { AddressSearch } from '@/components/business/settings/address-search';
 import { BusinessTypeSelect } from '@/components/business/settings/business-type-select';
 import { FormLabel } from '@/components/business/settings/form-label';
@@ -56,7 +56,7 @@ export function SettingsClient({
     if (
       (field === 'description' || field === 'businessNotice') &&
       typeof value === 'string' &&
-      hasScriptInjection(value)
+      !validateScriptInjection(value)
     ) {
       return; // 스크립트 입력 무시
     }

--- a/timefit-front/src/app/(business)/b/settings/settings-client.tsx
+++ b/timefit-front/src/app/(business)/b/settings/settings-client.tsx
@@ -1,16 +1,11 @@
 'use client';
 
-import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Script from 'next/script';
 
-import type {
-  BusinessProfileDetail,
-  UpdateBusinessRequest,
-} from '@/types/business/business-detail';
+import type { BusinessProfileDetail } from '@/types/business/business-detail';
 import { useUpdateBusiness } from '@/hooks/business/mutations/use-update-business';
-import { validateBusinessProfileForm } from '@/lib/validators/business-validators';
-import { validateScriptInjection } from '@/lib/validators/input-validators';
+import { useBusinessProfileForm } from '@/hooks/business/use-business-profile-form';
 import { AddressSearch } from '@/components/business/settings/address-search';
 import { BusinessTypeSelect } from '@/components/business/settings/business-type-select';
 import { FormLabel } from '@/components/business/settings/form-label';
@@ -29,66 +24,14 @@ export function SettingsClient({
                                  businessId,
                                }: SettingsClientProps) {
   const router = useRouter();
-  const [formData, setFormData] = useState<UpdateBusinessRequest>({});
-  const [phoneError, setPhoneError] = useState('');
-  const [emailError, setEmailError] = useState('');
   const { updateBusiness, updating } = useUpdateBusiness(businessId);
-
-  // 현재 각 필드 값 (formData 우선, 없으면 initialBusiness)
-  const currentValues = useMemo(() => ({
-    businessName: formData.businessName ?? initialBusiness.businessName,
-    businessTypes: formData.businessTypes ?? initialBusiness.businessTypes,
-    address: formData.address ?? initialBusiness.address,
-    contactPhone: formData.contactPhone ?? initialBusiness.contactPhone,
-    contactEmail: formData.contactEmail ?? (initialBusiness.contactEmail ?? ''),
-    description: formData.description ?? initialBusiness.description,
-  }), [formData, initialBusiness]);
-
-  // 변경사항 감지 — formData에 하나라도 있으면 변경된 것
-  const hasChanges = Object.keys(formData).length > 0;
-
-  // 폼 입력 핸들러
-  const handleChange = (
-    field: keyof UpdateBusinessRequest,
-    value: string | string[]
-  ) => {
-    // 스크립트 차단 (description, businessNotice만 적용)
-    if (
-      (field === 'description' || field === 'businessNotice') &&
-      typeof value === 'string' &&
-      !validateScriptInjection(value)
-    ) {
-      return;
-    }
-    setFormData(prev => ({ ...prev, [field]: value }));
-  };
-
-  // 카카오 주소 검색
-  const handleAddressSearch = () => {
-    new (window as any).kakao.Postcode({
-      oncomplete: (data: any) => {
-        const addr =
-          data.userSelectedType === 'R'
-              ? data.roadAddress
-              : data.jibunAddress;
-        handleChange('address', addr);
-      },
-    }).open();
-  };
-
-  // 저장 핸들러
-  const handleSave = async () => {
-    const { isValid, errors } = validateBusinessProfileForm(formData);
-    setPhoneError(errors.contactPhone ?? '');
-    setEmailError(errors.contactEmail ?? '');
-    if (!isValid) return;
-
-    const success = await updateBusiness(formData);
-    if (success) {
-      setFormData({});
-      router.refresh();
-    }
-  };
+  const {
+    currentValues, hasChanges,
+    phoneError, emailError,
+    handleChange, handleAddressSearch, handleSave,
+  } = useBusinessProfileForm({
+    initialBusiness, updateBusiness, onSaveSuccess: () => router.refresh(),
+  });
 
   const isDisabled = updating || !hasChanges;
 

--- a/timefit-front/src/app/(business)/b/settings/settings-client.tsx
+++ b/timefit-front/src/app/(business)/b/settings/settings-client.tsx
@@ -9,6 +9,8 @@ import type {
   UpdateBusinessRequest,
 } from '@/types/business/business-detail';
 import { useUpdateBusiness } from '@/hooks/business/mutations/use-update-business';
+import { validateBusinessContactPhone } from '@/lib/validators/business-validators';
+import { hasScriptInjection } from '@/lib/validators/input-validators';
 import { AddressSearch } from '@/components/business/settings/address-search';
 import { BusinessTypeSelect } from '@/components/business/settings/business-type-select';
 import { FormLabel } from '@/components/business/settings/form-label';
@@ -21,12 +23,6 @@ interface SettingsClientProps {
   initialBusiness: BusinessProfileDetail;
   businessId: string;
 }
-
-// 한국 전화번호 정규식 (02-XXXX-XXXX, 010-XXXX-XXXX 등)
-const PHONE_REGEX = /^(0[2-9]\d?)-\d{3,4}-\d{4}$|^01[016789]-\d{3,4}-\d{4}$/;
-
-// 스크립트 인젝션 패턴 차단
-const SCRIPT_PATTERN = /<script|javascript:|on\w+\s*=/i;
 
 export function SettingsClient({
                                  initialBusiness,
@@ -60,7 +56,7 @@ export function SettingsClient({
     if (
       (field === 'description' || field === 'businessNotice') &&
       typeof value === 'string' &&
-      SCRIPT_PATTERN.test(value)
+      hasScriptInjection(value)
     ) {
       return; // 스크립트 입력 무시
     }
@@ -69,7 +65,7 @@ export function SettingsClient({
 
     // 연락처 유효성 검사
     if (field === 'contactPhone' && typeof value === 'string') {
-      if (value && !PHONE_REGEX.test(value)) {
+      if (value && !validateBusinessContactPhone(value)) {
         setPhoneError('올바른 전화번호 형식으로 입력해주세요 (예: 02-1234-5678)');
       } else {
         setPhoneError('');
@@ -92,8 +88,8 @@ export function SettingsClient({
       oncomplete: (data: any) => {
         const addr =
           data.userSelectedType === 'R'
-            ? data.roadAddress
-            : data.jibunAddress;
+              ? data.roadAddress
+              : data.jibunAddress;
         handleChange('address', addr);
       },
     }).open();

--- a/timefit-front/src/app/(business)/b/settings/settings-client.tsx
+++ b/timefit-front/src/app/(business)/b/settings/settings-client.tsx
@@ -9,7 +9,7 @@ import type {
   UpdateBusinessRequest,
 } from '@/types/business/business-detail';
 import { useUpdateBusiness } from '@/hooks/business/mutations/use-update-business';
-import { validateBusinessContactPhone } from '@/lib/validators/business-validators';
+import { validateBusinessProfileForm } from '@/lib/validators/business-validators';
 import { validateScriptInjection } from '@/lib/validators/input-validators';
 import { AddressSearch } from '@/components/business/settings/address-search';
 import { BusinessTypeSelect } from '@/components/business/settings/business-type-select';
@@ -58,28 +58,9 @@ export function SettingsClient({
       typeof value === 'string' &&
       !validateScriptInjection(value)
     ) {
-      return; // 스크립트 입력 무시
+      return;
     }
-
     setFormData(prev => ({ ...prev, [field]: value }));
-
-    // 연락처 유효성 검사
-    if (field === 'contactPhone' && typeof value === 'string') {
-      if (value && !validateBusinessContactPhone(value)) {
-        setPhoneError('올바른 전화번호 형식으로 입력해주세요 (예: 02-1234-5678)');
-      } else {
-        setPhoneError('');
-      }
-    }
-
-    // 이메일 유효성 검사
-    if (field === 'contactEmail' && typeof value === 'string') {
-      if (value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
-        setEmailError('올바른 이메일 형식으로 입력해주세요');
-      } else {
-        setEmailError('');
-      }
-    }
   };
 
   // 카카오 주소 검색
@@ -97,16 +78,19 @@ export function SettingsClient({
 
   // 저장 핸들러
   const handleSave = async () => {
-    if (phoneError || emailError) return;
+    const { isValid, errors } = validateBusinessProfileForm(formData);
+    setPhoneError(errors.contactPhone ?? '');
+    setEmailError(errors.contactEmail ?? '');
+    if (!isValid) return;
 
     const success = await updateBusiness(formData);
     if (success) {
       setFormData({});
-      router.refresh(); // window.location.reload() 대신 Next.js 방식
+      router.refresh();
     }
   };
 
-  const isDisabled = updating || !hasChanges || !!phoneError || !!emailError;
+  const isDisabled = updating || !hasChanges;
 
   return (
     <>

--- a/timefit-front/src/hooks/business/calendar/use-calendar-data.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar-data.ts
@@ -1,0 +1,25 @@
+import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+
+import type { BusinessReservationItem } from '@/types/business/reservation';
+import { businessReservationService } from '@/services/reservation/reservation-business-service.client';
+
+/**
+ * 캘린더 예약 데이터 fetch 담당
+ */
+export function useCalendarData(businessId: string, initialReservations: BusinessReservationItem[]) {
+  const [allReservations, setAllReservations] = useState<BusinessReservationItem[]>(initialReservations);
+
+  const fetchReservations = useCallback(async (start: string, end: string) => {
+    try {
+      const result = await businessReservationService.getReservations(businessId, {
+        startDate: start,
+        endDate: end,
+        size: 100,
+      });
+      if (result.success && result.data) setAllReservations(result.data.reservations);
+    } catch { toast.error('예약 데이터를 불러오는 데 실패했습니다.'); }
+  }, [businessId]);
+
+  return { allReservations, fetchReservations };
+}

--- a/timefit-front/src/hooks/business/calendar/use-calendar-filter.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar-filter.ts
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+/**
+ * 캘린더 상태 필터 토글 담당
+ * 최소 1개 상태는 항상 활성화 보장
+ */
+export function useCalendarFilter(initialStatuses: string[] = ['CONFIRMED', 'COMPLETED']) {
+  const [activeStatuses, setActiveStatuses] = useState<Set<string>>(new Set(initialStatuses));
+
+  const toggleStatus = (status: string) => {
+    setActiveStatuses(prev => {
+      const next = new Set(prev);
+      if (next.has(status)) {
+        if (next.size === 1) return prev; // 최소 1개 유지
+        next.delete(status);
+      } else {
+        next.add(status);
+      }
+      return next;
+    });
+  };
+
+  return { activeStatuses, toggleStatus };
+}

--- a/timefit-front/src/hooks/business/calendar/use-calendar-modal.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar-modal.ts
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import type { BusinessReservationDetail } from '@/types/business/reservation';
+import { businessReservationService } from '@/services/reservation/reservation-business-service.client';
+
+/**
+ * 캘린더 이벤트 클릭 시 예약 상세 모달 담당
+ */
+export function useCalendarModal(businessId: string) {
+  const [detailModal, setDetailModal] = useState<{
+    isOpen: boolean;
+    detail: BusinessReservationDetail | null;
+  }>({ isOpen: false, detail: null });
+
+  const handleEventClick = async (reservationId: string) => {
+    const result = await businessReservationService.getReservationDetail(businessId, reservationId);
+    if (!result.success || !result.data) {
+      toast.error('상세 정보를 불러오는 데 실패했습니다.');
+      return;
+    }
+    setDetailModal({ isOpen: true, detail: result.data });
+  };
+
+  const closeDetailModal = () => setDetailModal({ isOpen: false, detail: null });
+
+  return { detailModal, handleEventClick, closeDetailModal };
+}

--- a/timefit-front/src/hooks/business/calendar/use-calendar-scale.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar-scale.ts
@@ -1,0 +1,40 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type { ViewType } from '@/types/business/calendar';
+import { CALENDAR_MIN_HEIGHT } from '@/lib/constants/calendar';
+
+const SCALE_BREAKPOINT = 510;
+
+/**
+ * 캘린더 반응형 scale 처리
+ * 510px 이하에서 월/연 뷰를 비율 축소
+ * FullCalendar(주/일 뷰)는 transform 호환 안되므로 minWidth + 스크롤 처리
+ */
+export function useCalendarScale(currentView: ViewType) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useEffect(() => {
+    const handleResize = () => {
+      const width = window.innerWidth - 256; // 사이드바 너비 제외
+      setScale(width < SCALE_BREAKPOINT ? Math.max(0.6, width / SCALE_BREAKPOINT) : 1);
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const containerStyle = useMemo(() => ({
+    height: 'calc(100vh - 64px)',
+    minHeight: CALENDAR_MIN_HEIGHT,
+    transformOrigin: 'top left',
+    transform: scale < 1 && (currentView === 'month' || currentView === 'year')
+      ? `scale(${scale})` : undefined,
+    width: scale < 1 && (currentView === 'month' || currentView === 'year')
+      ? `${100 / scale}%` : undefined,
+    minWidth: currentView === 'timeGridWeek' || currentView === 'timeGridDay'
+      ? 506 : undefined,
+  }), [scale, currentView]);
+
+  return { containerRef, containerStyle };
+}

--- a/timefit-front/src/hooks/business/calendar/use-calendar-view.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar-view.ts
@@ -1,0 +1,109 @@
+import { useCallback, useRef, useState } from 'react';
+import FullCalendar from '@fullcalendar/react';
+import type { DatesSetArg } from '@fullcalendar/core';
+import dayjs from 'dayjs';
+
+import type { ViewType } from '@/types/business/calendar';
+
+interface UseCalendarViewProps {
+  onFetchReservations: (start: string, end: string) => void;
+}
+
+/**
+ * 캘린더 뷰 전환 및 날짜 이동 담당
+ * calendarRef(FullCalendar API), currentView, currentDate, yearViewYear 상태 관리
+ */
+export function useCalendarView({ onFetchReservations }: UseCalendarViewProps) {
+  const calendarRef = useRef<FullCalendar>(null);
+  const [currentView, setCurrentView] = useState<ViewType>('month');
+  const [currentDate, setCurrentDate] = useState(dayjs());
+  const [yearViewYear, setYearViewYear] = useState(dayjs().year());
+
+  const titleText = (() => {
+    if (currentView === 'year') return `${yearViewYear}년`;
+    if (currentView === 'month') return `${currentDate.year()}년 ${currentDate.month() + 1}월`;
+    if (currentView === 'timeGridDay') return `${currentDate.year()}년 ${currentDate.month() + 1}월 ${currentDate.date()}일`;
+    return calendarRef.current?.getApi().view.title ?? '';
+  })();
+
+  const handleDatesSet = useCallback((arg: DatesSetArg) => {
+    onFetchReservations(
+      dayjs(arg.start).format('YYYY-MM-DD'),
+      dayjs(arg.end).subtract(1, 'day').format('YYYY-MM-DD')
+    );
+  }, [onFetchReservations]);
+
+  const handleNavigate = (dir: number) => {
+    if (currentView === 'year') { setYearViewYear(y => y + dir); return; }
+    if (currentView === 'month') {
+      const next = currentDate.add(dir, 'month');
+      setCurrentDate(next);
+      onFetchReservations(next.startOf('month').format('YYYY-MM-DD'), next.endOf('month').format('YYYY-MM-DD'));
+      return;
+    }
+    if (currentView === 'timeGridDay') {
+      const next = currentDate.add(dir, 'day');
+      setCurrentDate(next);
+      calendarRef.current?.getApi().gotoDate(next.toDate());
+      return;
+    }
+    if (dir === 1) calendarRef.current?.getApi().next();
+    else calendarRef.current?.getApi().prev();
+  };
+
+  const handleToday = () => {
+    const today = dayjs();
+    if (currentView === 'year') { setYearViewYear(today.year()); return; }
+    if (currentView === 'month') {
+      setCurrentDate(today);
+      onFetchReservations(today.startOf('month').format('YYYY-MM-DD'), today.endOf('month').format('YYYY-MM-DD'));
+      return;
+    }
+    setCurrentDate(today);
+    calendarRef.current?.getApi().today();
+  };
+
+  const handleViewChange = (view: ViewType) => {
+    setCurrentView(view);
+    if (view === 'year' || view === 'month') return;
+    calendarRef.current?.getApi().changeView(view);
+  };
+
+  const handleMonthClick = (year: number, month: number) => {
+    const date = dayjs(new Date(year, month, 1));
+    setCurrentDate(date);
+    setCurrentView('month');
+    onFetchReservations(date.startOf('month').format('YYYY-MM-DD'), date.endOf('month').format('YYYY-MM-DD'));
+  };
+
+  const handleDayClick = (year: number, month: number, day: number) => {
+    const date = dayjs(new Date(year, month, day));
+    setCurrentDate(date);
+    setCurrentView('timeGridWeek');
+    calendarRef.current?.getApi().changeView('timeGridWeek');
+    calendarRef.current?.getApi().gotoDate(date.toDate());
+  };
+
+  const handleMoreClick = (dateStr: string) => {
+    const date = dayjs(dateStr);
+    setCurrentDate(date);
+    setCurrentView('timeGridDay');
+    calendarRef.current?.getApi().changeView('timeGridDay');
+    calendarRef.current?.getApi().gotoDate(date.toDate());
+  };
+
+  return {
+    calendarRef,
+    currentView,
+    currentDate,
+    yearViewYear,
+    titleText,
+    handleDatesSet,
+    handleNavigate,
+    handleToday,
+    handleViewChange,
+    handleMonthClick,
+    handleDayClick,
+    handleMoreClick,
+  };
+}

--- a/timefit-front/src/hooks/business/calendar/use-calendar.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar.ts
@@ -16,50 +16,13 @@ interface UseCalendarProps {
  * 각 역할별 sub-hook을 조합하여 calendar-client.tsx에 단일 진입점 제공
  */
 export function useCalendar({ initialReservations, businessId }: UseCalendarProps) {
-  const { allReservations, fetchReservations } = useCalendarData(businessId, initialReservations);
-  const { activeStatuses, toggleStatus } = useCalendarFilter();
-  const { detailModal, handleEventClick, closeDetailModal } = useCalendarModal(businessId);
-  const {
-    calendarRef,
-    currentView,
-    currentDate,
-    yearViewYear,
-    titleText,
-    handleDatesSet,
-    handleNavigate,
-    handleToday,
-    handleViewChange,
-    handleMonthClick,
-    handleDayClick,
-    handleMoreClick,
-  } = useCalendarView({ onFetchReservations: fetchReservations });
-  const { containerRef, containerStyle } = useCalendarScale(currentView);
+  const data = useCalendarData(businessId, initialReservations);
+  const filter = useCalendarFilter();
+  const modal = useCalendarModal(businessId);
+  const view = useCalendarView({ onFetchReservations: data.fetchReservations });
+  const scale = useCalendarScale(view.currentView);
 
-  const fcEvents = toCalendarEvents(allReservations, activeStatuses);
+  const fcEvents = toCalendarEvents(data.allReservations, filter.activeStatuses);
 
-  return {
-    // refs
-    calendarRef,
-    containerRef,
-    // 상태
-    currentView,
-    currentDate,
-    yearViewYear,
-    titleText,
-    activeStatuses,
-    fcEvents,
-    detailModal,
-    containerStyle,
-    // 핸들러
-    toggleStatus,
-    handleDatesSet,
-    handleNavigate,
-    handleToday,
-    handleViewChange,
-    handleMonthClick,
-    handleDayClick,
-    handleMoreClick,
-    handleEventClick,
-    closeDetailModal,
-  };
+  return { view, scale, filter, modal, data, fcEvents };
 }

--- a/timefit-front/src/hooks/business/calendar/use-calendar.ts
+++ b/timefit-front/src/hooks/business/calendar/use-calendar.ts
@@ -1,0 +1,65 @@
+import type { BusinessReservationItem } from '@/types/business/reservation';
+import { toCalendarEvents } from '@/lib/data/calendar/calendar-event-mapper';
+import { useCalendarData } from './use-calendar-data';
+import { useCalendarFilter } from './use-calendar-filter';
+import { useCalendarModal } from './use-calendar-modal';
+import { useCalendarScale } from './use-calendar-scale';
+import { useCalendarView } from './use-calendar-view';
+
+interface UseCalendarProps {
+  initialReservations: BusinessReservationItem[];
+  businessId: string;
+}
+
+/**
+ * 캘린더 Facade hook
+ * 각 역할별 sub-hook을 조합하여 calendar-client.tsx에 단일 진입점 제공
+ */
+export function useCalendar({ initialReservations, businessId }: UseCalendarProps) {
+  const { allReservations, fetchReservations } = useCalendarData(businessId, initialReservations);
+  const { activeStatuses, toggleStatus } = useCalendarFilter();
+  const { detailModal, handleEventClick, closeDetailModal } = useCalendarModal(businessId);
+  const {
+    calendarRef,
+    currentView,
+    currentDate,
+    yearViewYear,
+    titleText,
+    handleDatesSet,
+    handleNavigate,
+    handleToday,
+    handleViewChange,
+    handleMonthClick,
+    handleDayClick,
+    handleMoreClick,
+  } = useCalendarView({ onFetchReservations: fetchReservations });
+  const { containerRef, containerStyle } = useCalendarScale(currentView);
+
+  const fcEvents = toCalendarEvents(allReservations, activeStatuses);
+
+  return {
+    // refs
+    calendarRef,
+    containerRef,
+    // 상태
+    currentView,
+    currentDate,
+    yearViewYear,
+    titleText,
+    activeStatuses,
+    fcEvents,
+    detailModal,
+    containerStyle,
+    // 핸들러
+    toggleStatus,
+    handleDatesSet,
+    handleNavigate,
+    handleToday,
+    handleViewChange,
+    handleMonthClick,
+    handleDayClick,
+    handleMoreClick,
+    handleEventClick,
+    closeDetailModal,
+  };
+}

--- a/timefit-front/src/hooks/business/use-business-profile-form.ts
+++ b/timefit-front/src/hooks/business/use-business-profile-form.ts
@@ -1,0 +1,90 @@
+import { useMemo, useState } from 'react';
+
+import type {
+  BusinessProfileDetail,
+  UpdateBusinessRequest,
+} from '@/types/business/business-detail';
+import { validateBusinessProfileForm } from '@/lib/validators/business-validators';
+import { validateScriptInjection } from '@/lib/validators/input-validators';
+
+interface UseBusinessProfileFormProps {
+  initialBusiness: BusinessProfileDetail;
+  onSaveSuccess: () => void;
+  updateBusiness: (data: UpdateBusinessRequest) => Promise<boolean>;
+}
+
+export function useBusinessProfileForm({
+                                         initialBusiness,
+                                         onSaveSuccess,
+                                         updateBusiness,
+                                       }: UseBusinessProfileFormProps) {
+  const [formData, setFormData] = useState<UpdateBusinessRequest>({});
+  const [phoneError, setPhoneError] = useState('');
+  const [emailError, setEmailError] = useState('');
+
+  // 현재 각 필드 값 (formData 우선, 없으면 initialBusiness)
+  const currentValues = useMemo(() => ({
+    businessName: formData.businessName ?? initialBusiness.businessName,
+    businessTypes: formData.businessTypes ?? initialBusiness.businessTypes,
+    address: formData.address ?? initialBusiness.address,
+    contactPhone: formData.contactPhone ?? initialBusiness.contactPhone,
+    contactEmail: formData.contactEmail ?? (initialBusiness.contactEmail ?? ''),
+    description: formData.description ?? initialBusiness.description,
+  }), [formData, initialBusiness]);
+
+  // 변경사항 감지 — formData에 하나라도 있으면 변경된 것
+  const hasChanges = Object.keys(formData).length > 0;
+
+  // 폼 입력 핸들러
+  const handleChange = (
+    field: keyof UpdateBusinessRequest,
+    value: string | string[]
+  ) => {
+    // 스크립트 차단 (description, businessNotice만 적용)
+    if (
+      (field === 'description' || field === 'businessNotice') &&
+      typeof value === 'string' &&
+      !validateScriptInjection(value)
+    ) {
+      return;
+    }
+    setFormData(prev => ({ ...prev, [field]: value }));
+  };
+
+  // 카카오 주소 검색
+  const handleAddressSearch = () => {
+    new (window as any).kakao.Postcode({
+      oncomplete: (data: any) => {
+        const addr =
+          data.userSelectedType === 'R'
+            ? data.roadAddress
+            : data.jibunAddress;
+        handleChange('address', addr);
+      },
+    }).open();
+  };
+
+  // 저장 핸들러
+  const handleSave = async () => {
+    const { isValid, errors } = validateBusinessProfileForm(formData);
+    setPhoneError(errors.contactPhone ?? '');
+    setEmailError(errors.contactEmail ?? '');
+    if (!isValid) return;
+
+    const success = await updateBusiness(formData);
+    if (success) {
+      setFormData({});
+      onSaveSuccess();
+    }
+  };
+
+  return {
+    currentValues,
+    hasChanges,
+    phoneError,
+    emailError,
+    handleChange,
+    handleAddressSearch,
+    handleSave,
+  };
+}

--- a/timefit-front/src/hooks/business/use-customers.ts
+++ b/timefit-front/src/hooks/business/use-customers.ts
@@ -1,0 +1,133 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import type {
+  BusinessCustomerDetail,
+  BusinessCustomerItem,
+  CustomerSortType,
+} from '@/types/business/customer-business';
+import type { PaginationInfo } from '@/types/business/reservation';
+import { businessCustomerService } from '@/services/business/customer-business-service.client';
+
+interface UseCustomersProps {
+  initialCustomers: BusinessCustomerItem[];
+  initialPagination: PaginationInfo;
+  businessId: string;
+}
+
+export function useCustomers({
+                               initialCustomers,
+                               initialPagination,
+                               businessId,
+                             }: UseCustomersProps) {
+  const [customers, setCustomers] = useState<BusinessCustomerItem[]>(initialCustomers);
+  const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
+  const [isLoading, setIsLoading] = useState(false);
+  const [currentKeyword, setCurrentKeyword] = useState('');
+  const [currentSortBy, setCurrentSortBy] = useState<CustomerSortType>('LAST_VISIT');
+
+  // 상세 모달
+  const [detailModal, setDetailModal] = useState<{
+    isOpen: boolean;
+    detail: BusinessCustomerDetail | null;
+  }>({ isOpen: false, detail: null });
+
+  // 메모 다이얼로그
+  const [memoDialog, setMemoDialog] = useState<{
+    isOpen: boolean;
+    customerId: string;
+    currentMemo: string | null;
+  }>({ isOpen: false, customerId: '', currentMemo: null });
+
+  // 검색/정렬 변경
+  const handleSearch = async (keyword: string, sortBy: CustomerSortType) => {
+    try {
+      setIsLoading(true);
+      const result = await businessCustomerService.getCustomers(businessId, {
+        keyword, sortBy, page: 0, size: 20,
+      });
+      if (!result.success) { toast.error('조회에 실패했습니다.'); return; }
+      setCurrentKeyword(keyword);
+      setCurrentSortBy(sortBy);
+      setCustomers(result.data!.customers);
+      setPagination(result.data!.pagination);
+    } catch {
+      toast.error('조회 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 페이지 이동
+  const handlePageChange = async (page: number) => {
+    try {
+      setIsLoading(true);
+      const result = await businessCustomerService.getCustomers(businessId, {
+        keyword: currentKeyword, sortBy: currentSortBy, page, size: 20,
+      });
+      if (!result.success) { toast.error('페이지 로드에 실패했습니다.'); return; }
+      setCustomers(result.data!.customers);
+      setPagination(result.data!.pagination);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch {
+      toast.error('페이지 로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 고객 상세
+  const handleDetail = async (customerId: string) => {
+    const result = await businessCustomerService.getCustomerDetail(businessId, customerId);
+    if (!result.success || !result.data) {
+      toast.error(result.message || '상세 정보를 불러오는 데 실패했습니다.');
+      return;
+    }
+    setDetailModal({ isOpen: true, detail: result.data });
+  };
+
+  const closeDetailModal = () => setDetailModal({ isOpen: false, detail: null });
+
+  // 메모 편집 열기
+  const handleMemo = (customerId: string, currentMemo: string | null) => {
+    setMemoDialog({ isOpen: true, customerId, currentMemo });
+  };
+
+  const closeMemoDialog = () =>
+    setMemoDialog({ isOpen: false, customerId: '', currentMemo: null });
+
+  // 메모 저장
+  const handleMemoSave = async (memo: string | null) => {
+    const result = await businessCustomerService.upsertCustomerMemo(
+      businessId,
+      memoDialog.customerId,
+      memo
+    );
+    if (!result.success) {
+      toast.error(result.message || '메모 저장에 실패했습니다.');
+      return;
+    }
+    setCustomers(prev => prev.map(c =>
+      c.customerId === memoDialog.customerId ? { ...c, memo } : c
+    ));
+    toast.success('메모가 저장되었습니다.');
+    closeMemoDialog();
+  };
+
+  return {
+    // 상태
+    customers,
+    pagination,
+    isLoading,
+    detailModal,
+    memoDialog,
+    // 핸들러
+    handleSearch,
+    handlePageChange,
+    handleDetail,
+    closeDetailModal,
+    handleMemo,
+    closeMemoDialog,
+    handleMemoSave,
+  };
+}

--- a/timefit-front/src/hooks/business/use-reservations.ts
+++ b/timefit-front/src/hooks/business/use-reservations.ts
@@ -1,0 +1,157 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import dayjs from 'dayjs';
+
+import type {
+  BusinessReservationDetail,
+  BusinessReservationItem,
+  PaginationInfo,
+  ReservationStats,
+} from '@/types/business/reservation';
+import { businessReservationService } from '@/services/reservation/reservation-business-service.client';
+import type { FilterValues } from '@/components/business/reservations/reservation-filter-toolbar';
+
+interface UseReservationsProps {
+  initialReservations: BusinessReservationItem[];
+  initialPagination: PaginationInfo;
+  initialStats: ReservationStats;
+  businessId: string;
+}
+
+export function useReservations({
+                                  initialReservations,
+                                  initialPagination,
+                                  initialStats,
+                                  businessId,
+                                }: UseReservationsProps) {
+  const [reservations, setReservations] = useState<BusinessReservationItem[]>(initialReservations);
+  const [pagination, setPagination] = useState<PaginationInfo>(initialPagination);
+  const [stats, setStats] = useState<ReservationStats>(initialStats);
+  const [isLoading, setIsLoading] = useState(false);
+  const [detailModal, setDetailModal] = useState<{
+    isOpen: boolean;
+    detail: BusinessReservationDetail | null;
+  }>({ isOpen: false, detail: null });
+
+  const today = dayjs();
+  const [currentFilters, setCurrentFilters] = useState<FilterValues>({
+    startDate: today.subtract(15, 'day').format('YYYY-MM-DD'),
+    endDate: today.add(15, 'day').format('YYYY-MM-DD'),
+  });
+
+  // 통계 갱신
+  const refreshStats = async (filters: FilterValues) => {
+    const result = await businessReservationService.getReservationStats(businessId, filters);
+    if (result.success && result.data) setStats(result.data);
+  };
+
+  // 상세 보기
+  const handleDetail = async (reservationId: string) => {
+    const result = await businessReservationService.getReservationDetail(businessId, reservationId);
+    if (!result.success || !result.data) {
+      toast.error(result.message || '상세 정보를 불러오는 데 실패했습니다.');
+      return;
+    }
+    setDetailModal({ isOpen: true, detail: result.data });
+  };
+
+  const closeDetailModal = () => setDetailModal({ isOpen: false, detail: null });
+
+  // 필터 검색 — 목록 + 통계 동시 갱신
+  const handleSearch = async (filters: FilterValues) => {
+    try {
+      setIsLoading(true);
+      const [listResult, statsResult] = await Promise.all([
+        businessReservationService.getReservations(businessId, { ...filters, page: 0, size: 20 }),
+        businessReservationService.getReservationStats(businessId, filters),
+      ]);
+      if (!listResult.success) { toast.error('조회에 실패했습니다.'); return; }
+      setCurrentFilters(filters);
+      setReservations(listResult.data!.reservations);
+      setPagination(listResult.data!.pagination);
+      if (statsResult.success && statsResult.data) setStats(statsResult.data);
+    } catch {
+      toast.error('조회 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 페이지 이동
+  const handlePageChange = async (page: number) => {
+    try {
+      setIsLoading(true);
+      const result = await businessReservationService.getReservations(
+        businessId, { ...currentFilters, page, size: 20 }
+      );
+      if (!result.success) { toast.error('페이지 로드에 실패했습니다.'); return; }
+      setReservations(result.data!.reservations);
+      setPagination(result.data!.pagination);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    } catch {
+      toast.error('페이지 로드 중 오류가 발생했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 액션 핸들러
+  const handleApprove = async (reservationId: string) => {
+    const result = await businessReservationService.approveReservation(businessId, reservationId);
+    if (!result.success) { toast.error(result.message || '승인에 실패했습니다.'); return; }
+    setReservations(prev => prev.map(r =>
+      r.reservationId === reservationId ? { ...r, status: 'CONFIRMED' as const, requiresAction: false } : r
+    ));
+    toast.success('예약을 승인했습니다.');
+    await refreshStats(currentFilters);
+  };
+
+  const handleReject = async (reservationId: string) => {
+    const result = await businessReservationService.rejectReservation(businessId, reservationId);
+    if (!result.success) { toast.error(result.message || '거절에 실패했습니다.'); return; }
+    setReservations(prev => prev.map(r =>
+      r.reservationId === reservationId ? { ...r, status: 'REJECTED' as const, requiresAction: false } : r
+    ));
+    toast.success('예약을 거절했습니다.');
+    await refreshStats(currentFilters);
+  };
+
+  const handleComplete = async (reservationId: string) => {
+    const result = await businessReservationService.completeReservation(businessId, reservationId);
+    if (!result.success) { toast.error(result.message || '완료 처리에 실패했습니다.'); return; }
+    setReservations(prev => prev.map(r =>
+      r.reservationId === reservationId ? { ...r, status: 'COMPLETED' as const, requiresAction: false } : r
+    ));
+    toast.success('예약을 완료 처리했습니다.');
+    await refreshStats(currentFilters);
+  };
+
+  const handleNoShow = async (reservationId: string) => {
+    const result = await businessReservationService.noShowReservation(businessId, reservationId);
+    if (!result.success) { toast.error(result.message || '노쇼 처리에 실패했습니다.'); return; }
+    setReservations(prev => prev.map(r =>
+      r.reservationId === reservationId ? { ...r, status: 'NO_SHOW' as const, requiresAction: false } : r
+    ));
+    toast.success('노쇼 처리했습니다.');
+    await refreshStats(currentFilters);
+  };
+
+  return {
+    // 상태
+    reservations,
+    pagination,
+    stats,
+    isLoading,
+    detailModal,
+    currentFilters,
+    // 핸들러
+    handleDetail,
+    closeDetailModal,
+    handleSearch,
+    handlePageChange,
+    handleApprove,
+    handleReject,
+    handleComplete,
+    handleNoShow,
+  };
+}

--- a/timefit-front/src/lib/data/calendar/calendar-event-mapper.ts
+++ b/timefit-front/src/lib/data/calendar/calendar-event-mapper.ts
@@ -1,0 +1,32 @@
+import type { EventInput } from '@fullcalendar/core';
+import dayjs from 'dayjs';
+
+import type { BusinessReservationItem } from '@/types/business/reservation';
+import { RESERVATION_STATUS_FILTERS } from '@/lib/constants/reservation-status';
+
+/**
+ * 사업자용 예약 목록을 FullCalendar 이벤트 형식으로 변환
+ * @param reservations 예약 목록
+ * @param activeStatuses 표시할 상태 집합
+ */
+export function toCalendarEvents(
+  reservations: BusinessReservationItem[],
+  activeStatuses: Set<string>
+): EventInput[] {
+  return reservations
+    .filter(r => activeStatuses.has(r.status))
+    .map(r => {
+      const filter = RESERVATION_STATUS_FILTERS.find(f => f.value === r.status);
+      return {
+        id: r.reservationId,
+        title: `${r.customerName} · ${r.reservationDuration}분`,
+        start: `${r.reservationDate}T${r.reservationTime}`,
+        end: dayjs(`${r.reservationDate}T${r.reservationTime}`)
+          .add(r.reservationDuration, 'minute')
+          .format('YYYY-MM-DDTHH:mm:ss'),
+        backgroundColor: filter?.eventColor ?? '#e5e7eb',
+        borderColor: filter?.eventColor ?? '#e5e7eb',
+        textColor: filter?.eventTextColor ?? '#374151',
+      };
+    });
+}

--- a/timefit-front/src/lib/validators/business-validators.ts
+++ b/timefit-front/src/lib/validators/business-validators.ts
@@ -63,3 +63,13 @@ export function validateBusinessSignupForm(
     errors,
   };
 }
+
+/**
+ * 업체 연락처 유효성 검사 (일반 전화 + 휴대폰)
+ * 예: 02-1234-5678, 010-1234-5678
+ * 고객 휴대폰 번호 검증은 auth-validators.ts 참고
+ * @returns true면 유효한 형식
+ */
+export function validateBusinessContactPhone(value: string): boolean {
+  return contactPhonePattern.test(value);
+}

--- a/timefit-front/src/lib/validators/business-validators.ts
+++ b/timefit-front/src/lib/validators/business-validators.ts
@@ -2,14 +2,58 @@ import {
   BusinessSignupFormData,
   BusinessSignupFormErrors,
 } from '@/types/auth/business/create-business';
+import type { UpdateBusinessRequest } from '@/types/business/business-detail';
+import { validateScriptInjection } from '@/lib/validators/input-validators';
 
 interface BusinessSignupValidationResult {
   isValid: boolean;
   errors: BusinessSignupFormErrors;
 }
 
+interface BusinessProfileFormErrors {
+  contactPhone?: string;
+  contactEmail?: string;
+}
+
+interface BusinessProfileValidationResult {
+  isValid: boolean;
+  errors: BusinessProfileFormErrors;
+}
+
 const businessNumberPattern = /^(\d{3})-(\d{2})-(\d{5})$/;
 const contactPhonePattern = /^(0\d{1,2})-\d{3,4}-\d{4}$/;
+const emailPattern = /\S+@\S+\.\S+/;
+
+/**
+ * 업체 정보 수정 폼 유효성 검증
+ * contactPhone, contactEmail, description, businessNotice 검증
+ */
+export function validateBusinessProfileForm(
+  formData: UpdateBusinessRequest
+): BusinessProfileValidationResult {
+  const errors: BusinessProfileFormErrors = {};
+
+  if (formData.contactPhone && !contactPhonePattern.test(formData.contactPhone)) {
+    errors.contactPhone = '올바른 전화번호 형식으로 입력해주세요 (예: 02-1234-5678)';
+  }
+
+  if (formData.contactEmail && !emailPattern.test(formData.contactEmail)) {
+    errors.contactEmail = '올바른 이메일 형식으로 입력해주세요';
+  }
+
+  if (formData.description && !validateScriptInjection(formData.description)) {
+    errors.contactEmail = '허용되지 않는 문자가 포함되어 있습니다.';
+  }
+
+  if (formData.businessNotice && !validateScriptInjection(formData.businessNotice)) {
+    errors.contactEmail = '허용되지 않는 문자가 포함되어 있습니다.';
+  }
+
+  return {
+    isValid: Object.keys(errors).length === 0,
+    errors,
+  };
+}
 
 /**
  * 초기 사업자 회원가입 폼 데이터

--- a/timefit-front/src/lib/validators/input-validators.ts
+++ b/timefit-front/src/lib/validators/input-validators.ts
@@ -1,0 +1,14 @@
+/**
+ * 일반 입력값 보안 검증
+ * 도메인에 관계없이 범용으로 사용
+ */
+
+/**
+ * 스크립트 인젝션 패턴 감지
+ * description, notice 등 자유 입력 필드에 적용
+ * @returns true면 위험한 입력 (차단 대상)
+ */
+export function hasScriptInjection(value: string): boolean {
+    const SCRIPT_PATTERN = /<script|javascript:|on\w+\s*=/i;
+    return SCRIPT_PATTERN.test(value);
+}

--- a/timefit-front/src/lib/validators/input-validators.ts
+++ b/timefit-front/src/lib/validators/input-validators.ts
@@ -8,7 +8,7 @@
  * description, notice 등 자유 입력 필드에 적용
  * @returns true면 위험한 입력 (차단 대상)
  */
-export function hasScriptInjection(value: string): boolean {
+export function validateScriptInjection(value: string): boolean {
     const SCRIPT_PATTERN = /<script|javascript:|on\w+\s*=/i;
     return SCRIPT_PATTERN.test(value);
 }

--- a/timefit-front/src/services/business/customer-business-service.client.ts
+++ b/timefit-front/src/services/business/customer-business-service.client.ts
@@ -1,6 +1,8 @@
 import type {
   GetBusinessCustomerDetailHandlerResponse,
+  GetBusinessCustomerListHandlerResponse,
   UpsertCustomerMemoHandlerResponse,
+  CustomerSortType,
 } from '@/types/business/customer-business';
 
 /**
@@ -37,6 +39,28 @@ class BusinessCustomerService {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ memo }),
       }
+    );
+    return response.json();
+  }
+
+  async getCustomers(
+    businessId: string,
+    params: {
+      keyword?: string;
+      sortBy?: CustomerSortType;
+      page?: number;
+      size?: number;
+    }
+  ): Promise<GetBusinessCustomerListHandlerResponse> {
+    const searchParams = new URLSearchParams();
+    if (params.keyword) searchParams.append('keyword', params.keyword);
+    if (params.sortBy) searchParams.append('sortBy', params.sortBy);
+    if (params.page !== undefined) searchParams.append('page', params.page.toString());
+    if (params.size !== undefined) searchParams.append('size', params.size.toString());
+
+    const response = await fetch(
+      `/api/business/${businessId}/customers?${searchParams.toString()}`,
+      { method: 'GET' }
     );
     return response.json();
   }

--- a/timefit-front/src/services/reservation/reservation-business-service.client.ts
+++ b/timefit-front/src/services/reservation/reservation-business-service.client.ts
@@ -1,6 +1,8 @@
 import type {
   BusinessReservationActionHandlerResponse,
   GetBusinessReservationDetailHandlerResponse,
+  GetBusinessReservationListHandlerResponse,
+  GetReservationStatsHandlerResponse,
 } from '@/types/business/reservation';
 
 /**
@@ -94,6 +96,60 @@ class BusinessReservationService {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ notes }),
       }
+    );
+    return response.json();
+  }
+
+  /**
+   * 예약 목록 조회
+   */
+  async getReservations(
+    businessId: string,
+    filters: {
+      status?: string;
+      startDate?: string;
+      endDate?: string;
+      customerName?: string;
+      page?: number;
+      size?: number;
+    }
+  ): Promise<GetBusinessReservationListHandlerResponse> {
+    const params = new URLSearchParams();
+    if (filters.status) params.append('status', filters.status);
+    if (filters.startDate) params.append('startDate', filters.startDate);
+    if (filters.endDate) params.append('endDate', filters.endDate);
+    if (filters.customerName) params.append('customerName', filters.customerName);
+    if (filters.page !== undefined) params.append('page', filters.page.toString());
+    if (filters.size !== undefined) params.append('size', filters.size.toString());
+
+    const response = await fetch(
+      `/api/business/${businessId}/reservations?${params.toString()}`,
+      { method: 'GET' }
+    );
+    return response.json();
+  }
+
+  /**
+   * 예약 통계 조회
+   */
+  async getReservationStats(
+    businessId: string,
+    filters: {
+      status?: string;
+      customerName?: string;
+      startDate?: string;
+      endDate?: string;
+    }
+  ): Promise<GetReservationStatsHandlerResponse> {
+    const params = new URLSearchParams();
+    if (filters.status) params.append('status', filters.status);
+    if (filters.customerName) params.append('customerName', filters.customerName);
+    if (filters.startDate) params.append('startDate', filters.startDate);
+    if (filters.endDate) params.append('endDate', filters.endDate);
+
+    const response = await fetch(
+      `/api/business/${businessId}/reservations/stats?${params.toString()}`,
+      { method: 'GET' }
     );
     return response.json();
   }


### PR DESCRIPTION
## Summary
#86 에서 구현된 사업자 페이지 클라이언트 컴포넌트 내에 혼재되어 있던 fetch, 검증, 상태 관리 로직을 각 역할에 맞는 계층으로 분리했습니다.

### Frontend
- 예약 현황 목록·통계 fetch 메서드를 service로 분리, 클라이언트 컴포넌트가 service를 통해 요청하도록 수정
- 예약 현황 상태 관리·액션 처리 로직을 전용 hook으로 추출
- 업체 정보 수정 시 폼 검증 로직을 전용 validator 함수로 추출
- 업체 정보 수정 시 폼 상태 관리·입력 핸들러를 전용 hook으로 추출
- 고객 목록 조회 메서드를 service로 분리, 클라이언트 컴포넌트가 service를 통해 요청하도록 수정
- 고객 목록 상태 관리·액션 처리 로직을 전용 hook으로 추출
- 캘린더 예약 이벤트 변환 로직을 lib/data로 분리
- 캘린더 뷰 전환·날짜 이동·예약 조회·상태 필터 로직을 역할별 hook으로 추출하고 Facade hook으로 통합
- 대시보드 로컬 타입 정의를 공용 타입 파일로 분리

## Related Issue
#88
